### PR TITLE
Bugfix/cmake and compile

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Configure C++ example Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: cmake -S cpp -B build-cpp -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
+        run: cmake -S cpp -B build-cpp -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_CLANG_TIDY="clang-tidy" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wconversion -Werror"
 
       # Note: the setup normally updates the environment variables but this does not seem to work with GitHub Actions
       - name: Configure C++ example Windows
@@ -187,7 +187,7 @@ jobs:
           $env:ids_peak_afl_DIR="$ids_peak\generic_sdk\afl\lib\x86_64\cmake\"
           $env:ids_peak_ipl_DIR="$ids_peak\generic_sdk\ipl\lib\x86_64\cmake\"
           $env:ids_peak_common_DIR="$ids_peak\common\lib\cmake\"
-          cmake -S cpp -B build-cpp -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+          cmake -S cpp -B build-cpp -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/W4 /WX"
         shell: powershell
 
       # - name: Build C example

--- a/cpp/nion_point_cloud/CMakeLists.txt
+++ b/cpp/nion_point_cloud/CMakeLists.txt
@@ -9,8 +9,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
-find_package(ids_peak REQUIRED)
-find_package(ids_peak_icv REQUIRED)
+find_package(ids_peak 1.12 REQUIRED)
+find_package(ids_peak_icv 1.1 REQUIRED)
 
 # These functions will add a post-build steps to your target
 # in order to copy all needed files (e.g. DLL's) to the output directory.

--- a/cpp/nion_point_cloud/main.cpp
+++ b/cpp/nion_point_cloud/main.cpp
@@ -192,7 +192,7 @@ std::shared_ptr<peak::core::DataStream> DeviceStartAcquisition(
 
     for (size_t i = 0; i < stream->NumBuffersAnnouncedMinRequired(); ++i)
     {
-        stream->QueueBuffer(stream->AllocAndAnnounceBuffer(payloadSize, nullptr));
+        stream->QueueBuffer(stream->AllocAndAnnounceBuffer(static_cast<size_t>(payloadSize), nullptr));
     }
 
     nodeMap->FindNode<peak::core::nodes::IntegerNode>("TLParamsLocked")->SetValue(1);


### PR DESCRIPTION
Fix cmake by using explicit dependency versions and also fix a compile error when warnings are enabled.

From now on this is automatically tested in the github actions