### PR TITLE
feat(.net):Add Nion point cloud example

### DIFF
--- a/csharp/NionPointCloud/NionPointCloud.csproj
+++ b/csharp/NionPointCloud/NionPointCloud.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>warnings</Nullable>
+    <RuntimeIdentifiers>
+        win-x86;win-x64;linux-x64;linux-arm;linux-arm64
+    </RuntimeIdentifiers>
+</PropertyGroup>
+
+<ItemGroup>
+    <PackageReference Include="IDSImaging.Peak.Common" Version="1.*" />
+    <PackageReference Include="IDSImaging.Peak.ICV" Version="1.*" />
+    <PackageReference Include="IDSImaging.Peak.API" Version="1.*" />
+</ItemGroup>
+
+</Project>

--- a/csharp/NionPointCloud/NionPointCloudFramework.csproj
+++ b/csharp/NionPointCloud/NionPointCloudFramework.csproj
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+    </PropertyGroup>
+    <PropertyGroup Label="Globals">
+        <ProjectGuid>{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}</ProjectGuid>
+        <Keyword>Win32Proj</Keyword>
+        <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+        <ProjectName>NionPointCloud</ProjectName>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+        <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+        <ManagedAssembly>true</ManagedAssembly>
+        <OutputType>Exe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <LangVersion>8.0</LangVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <BuildProject>false</BuildProject>
+    </PropertyGroup>
+    <Target Name="ValidateCommandLine" BeforeTargets="ResolveAssemblyReferences">
+        <Error Text=" The 'Platform' property must be set on the command line." Condition="'$(Platform)' == ''" />
+        <Error Text=" The 'Platform' property must not be set to Any/AnyCPU." Condition="$(Platform.Contains('Any'))" />
+    </Target>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+        <OutputPath>bin\x86\Debug\</OutputPath>
+        <DebugSymbols>true</DebugSymbols>
+        <DefineDebug>true</DefineDebug>
+        <PlatformTarget>x86</PlatformTarget>
+        <PlatformToolset>v143</PlatformToolset>
+        <AssemblyName>NionPointCloud</AssemblyName>
+        <StartAction>Program</StartAction>
+        <StartProgram>$(SolutionDir)$(OutputPath)NionPointCloud.exe</StartProgram>
+        <DebugType>full</DebugType>
+        <DefineConstants>TRACE;DEBUG</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <Optimize>false</Optimize>
+        <WarningLevel>3</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+        <OutputPath>bin\x86\Release\</OutputPath>
+        <PlatformTarget>x86</PlatformTarget>
+        <PlatformToolset>v143</PlatformToolset>
+        <AssemblyName>NionPointCloud</AssemblyName>
+        <StartAction>Program</StartAction>
+        <StartProgram>$(SolutionDir)$(OutputPath)NionPointCloud.exe</StartProgram>
+        <DebugType>none</DebugType>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>queue</ErrorReport>
+        <Optimize>true</Optimize>
+        <WarningLevel>1</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+        <OutputPath>bin\x64\Debug\</OutputPath>
+        <DebugSymbols>true</DebugSymbols>
+        <DefineDebug>true</DefineDebug>
+        <PlatformTarget>x64</PlatformTarget>
+        <PlatformToolset>v143</PlatformToolset>
+        <AssemblyName>NionPointCloud</AssemblyName>
+        <StartAction>Program</StartAction>
+        <StartProgram>$(SolutionDir)$(OutputPath)NionPointCloud.exe</StartProgram>
+        <DebugType>full</DebugType>
+        <DefineConstants>TRACE;DEBUG</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <Optimize>false</Optimize>
+        <WarningLevel>3</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+        <OutputPath>bin\x64\Release\</OutputPath>
+        <PlatformTarget>x64</PlatformTarget>
+        <PlatformToolset>v143</PlatformToolset>
+        <AssemblyName>NionPointCloud</AssemblyName>
+        <StartAction>Program</StartAction>
+        <StartProgram>$(SolutionDir)$(OutputPath)NionPointCloud.exe</StartProgram>
+        <DebugType>none</DebugType>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>queue</ErrorReport>
+        <Optimize>true</Optimize>
+        <WarningLevel>1</WarningLevel>
+    </PropertyGroup>
+    <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.CSharp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.CSharp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    </ImportGroup>
+    <PropertyGroup Label="UserMacros" />
+    <ItemGroup>
+        <Compile Include="Program.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="Microsoft.CSharp">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="PresentationCore">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="System">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="System.Core">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="System.Data">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="WindowsBase">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+        <Reference Include="netstandard">
+            <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        </Reference>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <ImportGroup Label="ExtensionTargets">
+    </ImportGroup>
+    <ItemGroup>
+        <PackageReference Include="IDSImaging.Peak.ICV" Version="1.*" />
+        <PackageReference Include="IDSImaging.Peak.Common" Version="1.*" />
+        <PackageReference Include="IDSImaging.Peak.API" Version="1.*" />
+    </ItemGroup>
+    <PropertyGroup>
+        <BuildDependsOn>
+            $(BuildDependsOn)
+        </BuildDependsOn>
+    </PropertyGroup>
+</Project>

--- a/csharp/NionPointCloud/Program.cs
+++ b/csharp/NionPointCloud/Program.cs
@@ -1,0 +1,405 @@
+// Copyright (C) 2026, IDS Imaging Development Systems GmbH.
+//
+// Permission to use, copy, modify, and/or distribute this software for
+// any purpose with or without fee is hereby granted.
+//
+// THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL
+// WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+// FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+// DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+// AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+// OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+using System;
+using IDSImaging.Peak.Common.Types;
+using IDSImaging.Peak.Common.Types.Geometry;
+using IDSImaging.Peak.ICV.Algorithms.Calibration;
+using IDSImaging.Peak.ICV.Algorithms.Thresholds;
+using IDSImaging.Peak.ICV.Algorithms.Transformations;
+using IDSImaging.Peak.ICV.IO;
+using IDSImaging.Peak.ICV.Types;
+using IDSImaging.Peak.API;
+using IDSImaging.Peak.API.Core;
+using IDSImaging.Peak.API.Core.File;
+using IDSImaging.Peak.API.Core.Nodes;
+using Buffer = IDSImaging.Peak.API.Core.Buffer;
+
+
+namespace IDSImaging.Peak.Samples.NionPointCloud
+{
+    /// <summary>
+    /// This example shows how to open and configure an IDS Nion camera.
+    /// It demonstrates how to acquire multipart image buffers containing a depth map and an intensity image,
+    /// and process this data into usable 3D information using the IDS peak ICV and generic APIs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The application:
+    /// <list type="bullet">
+    /// <item><description>Opens the first connected IDS Nion camera</description></item>
+    /// <item><description>Configures camera parameters such as exposure time and confidence threshold</description></item>
+    /// <item><description>Acquires multipart image data (depth map and intensity image)</description></item>
+    /// <item><description>Converts the raw depth map into metric floating-point coordinates</description></item>
+    /// <item><description>Filters invalid and out-of-range depth values</description></item>
+    /// <item><description>Undistorts depth and intensity images using factory calibration data</description></item>
+    /// <item><description>Generates a 3D point cloud with per-point intensity values (XYZI)</description></item>
+    /// <item><description>Writes depth maps, intensity images, and point cloud files to disk</description></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    internal static class Program
+    {
+        // -------------------------------------------------------------------------------------------------------------
+        // CONFIGURATION
+        // -------------------------------------------------------------------------------------------------------------
+
+        // Enable filtering of depth values based on the camera confidence image
+        private const bool _filterDepthMapByConfidenceEnabled = true;
+
+        // Pixels with confidence values below this threshold are marked as invalid. The Range is 0 to 4095.
+        private const int _confidenceThreshold = 100;
+
+        // Camera exposure time in microseconds
+        private const float _exposureTimeUs = 1000.0f;
+
+        // Enable filtering of depth values based on the Z distance
+        private const bool _filterDistanceEnabled = true;
+
+        // Valid Z distance interval in millimeters
+        private static readonly IntervalF _filterDistanceIntervalMm = new IntervalF(100.0f, 1000.0f);
+
+        // Number of images acquired in this sample
+        private const int _imageAcquisitionCount = 10;
+
+
+        // -------------------------------------------------------------------------------------------------------------
+        // MAIN
+        // -------------------------------------------------------------------------------------------------------------
+
+        private static int Main()
+        {
+            InitializeLibraries();
+
+            try
+            {
+                using Device device = OpenFirstConnectedDevice();
+                using NodeMap nodeMap = device.RemoteDevice().NodeMaps()[0];
+
+                DeviceResetToDefault(nodeMap);
+
+                if (_filterDepthMapByConfidenceEnabled)
+                {
+                    DeviceSetConfidenceThreshold(nodeMap, _confidenceThreshold);
+                }
+
+                DeviceSetExposureTime(nodeMap);
+
+                CalibrationParameters calibration = DeviceReadCalibrationParameters(nodeMap);
+                var min = DeviceGetDepthMinimumValidValue(nodeMap);
+                var max = DeviceGetDepthMaximumValidValue(nodeMap);
+                var scale = DeviceGetDepthScaleFactor(nodeMap);
+
+                // Undistortion object initialized with factory calibration data
+                using var undistortion = new Undistortion(calibration);
+
+                using DataStream stream = DeviceStartAcquisition(device, nodeMap);
+
+                for (var i = 0; i < _imageAcquisitionCount; i++)
+                {
+                    using Buffer buffer = stream.WaitForFinishedBuffer(DataStream.INFINITE_NUMBER);
+
+                    if (buffer.IsIncomplete())
+                    {
+                        Console.WriteLine($"Incomplete buffer {i}. Skipping.");
+                        stream.QueueBuffer(buffer);
+                        continue;
+                    }
+
+                    if (!buffer.HasNewData())
+                    {
+                        Console.WriteLine($"Buffer {i} has no new data. Skipping.");
+                        stream.QueueBuffer(buffer);
+                        continue;
+                    }
+
+                    if (!buffer.HasParts())
+                    {
+                        throw new Exception("Buffer has no parts. Aborting.");
+                    }
+
+                    (BufferPart depthPart, BufferPart intensityPart) = ExtractBufferParts(buffer);
+
+                    // -------------------------------------------------------------------------------------------------
+                    // Depth map processing
+                    // -------------------------------------------------------------------------------------------------
+
+                    // Create image from raw depth buffer and attach metadata
+                    using var rawDepth = new Image(depthPart.ToImageView());
+                    rawDepth.Metadata = AppendMetadataByDeviceMetadata(rawDepth.Metadata, nodeMap);
+
+                    // Convert depth values to floating-point metric coordinates
+                    using Image depth = rawDepth.ConvertPixelFormatWithFactor(
+                        PixelFormat.Coord3D_C32f, scale);
+
+                    // Remove invalid depth pixels and get region of only valid pixels
+                    var validPixelThreshold = new ThresholdF(new IntervalF(min, max));
+                    using Region region = validPixelThreshold.Process(depth);
+                    depth.Region = region;
+
+                    // Undistort the depth map
+                    using UndistortedImage undistortedDepth = undistortion.Process(depth);
+
+                    // Optional distance-based filtering
+                    if (_filterDistanceEnabled)
+                    {
+                        var distanceFilter = new ThresholdF(_filterDistanceIntervalMm);
+                        undistortedDepth.Region = distanceFilter.Process(undistortedDepth);
+                    }
+
+                    WriteDepthMapToFile(undistortedDepth, i);
+
+                    // -------------------------------------------------------------------------------------------------
+                    // Intensity image processing
+                    // -------------------------------------------------------------------------------------------------
+                    using var intensity = new Image(intensityPart.ToImageView());
+                    intensity.Metadata = AppendMetadataByDeviceMetadata(intensity.Metadata, nodeMap);
+
+                    using UndistortedImage undistortedIntensity = undistortion.Process(intensity);
+                    WriteIntensityToFile(undistortedIntensity, i);
+
+                    // Queue buffer that it can be reused. This can be done after the buffer data is no longer used.
+                    stream.QueueBuffer(buffer);
+
+                    // -------------------------------------------------------------------------------------------------
+                    // Point cloud generation
+                    // -------------------------------------------------------------------------------------------------
+                    using var pointCloud = new PointCloudXYZI(undistortedDepth, undistortedIntensity);
+                    WritePointCloudToFile(pointCloud, i);
+                }
+
+                DeviceStopAcquisition(nodeMap, stream);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error: " + e.Message);
+            }
+            finally
+            {
+                ExitLibraries();
+            }
+
+            return 0;
+        }
+
+        // -------------------------------------------------------------------------------------------------------------
+        // PEAK LIBRARY LIFECYCLE
+        // -------------------------------------------------------------------------------------------------------------
+
+        // Initialize peak core and peak ICV libraries
+        private static void InitializeLibraries()
+        {
+            ICV.Library.Init();
+            API.Library.Initialize();
+        }
+
+        // Shutdown peak libraries
+        private static void ExitLibraries()
+        {
+            try
+            {
+                ICV.Library.Exit();
+                API.Library.Close();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error: Exception occured while exiting libraries!");
+            }
+        }
+
+        // -------------------------------------------------------------------------------------------------------------
+        // DEVICE UTILITIES
+        // -------------------------------------------------------------------------------------------------------------
+
+        private static Device OpenFirstConnectedDevice()
+        {
+            using var deviceManager = DeviceManager.Instance();
+            deviceManager.Update();
+
+            foreach (DeviceDescriptor deviceDescriptor in deviceManager.Devices())
+            {
+                if (!deviceDescriptor.ModelName().Contains("NION") || !deviceDescriptor.IsOpenable())
+                {
+                    continue;
+                }
+
+                Device device = deviceDescriptor.OpenDevice(DeviceAccessType.Control);
+
+                return device;
+            }
+
+            throw new Exception("No IDS Nion device found.");
+        }
+
+        private static void DeviceResetToDefault(NodeMap nodeMap)
+        {
+            nodeMap.FindNode<EnumerationNode>("UserSetSelector").SetCurrentEntry("Default");
+
+            using CommandNode cmd = nodeMap.FindNode<CommandNode>("UserSetLoad");
+            cmd.Execute();
+            cmd.WaitUntilDone();
+        }
+
+        private static void DeviceSetConfidenceThreshold(NodeMap nodeMap, int threshold)
+        {
+            // Sets the gray value of all pixels in the Range component whose corresponding value in the Confidence
+            // component is below the set threshold to Scan3dInvalidDataValue.
+            nodeMap.FindNode<IntegerNode>("Scan3dRangeConfidenceThreshold").SetValue(threshold);
+        }
+
+        private static void DeviceSetExposureTime(NodeMap nodeMap)
+        {
+            nodeMap.FindNode<FloatNode>("ExposureTime").SetValue(_exposureTimeUs);
+        }
+
+        private static CalibrationParameters DeviceReadCalibrationParameters(NodeMap nodeMap)
+        {
+            using var adapter = new FileAdapter(nodeMap, "LensCalibrationData");
+
+            if (adapter.Size() <= 0)
+            {
+                throw new Exception("No factory calibration data available.");
+            }
+
+            return new CalibrationParameters(adapter.Read(adapter.Size()));
+        }
+
+        private static float DeviceGetDepthMinimumValidValue(NodeMap nodeMap)
+            => (float) nodeMap.FindNode<FloatNode>("Scan3dAxisMin").Value();
+
+        private static float DeviceGetDepthMaximumValidValue(NodeMap nodeMap)
+            => (float) nodeMap.FindNode<FloatNode>("Scan3dAxisMax").Value();
+
+        // Get the scale factor for converting depth values into metric units
+        private static float DeviceGetDepthScaleFactor(NodeMap nodeMap)
+            => (float) nodeMap.FindNode<FloatNode>("Scan3dCoordinateScale").Value();
+
+        // Append a metadata object with device binning and ROI information
+        // The metadata is required for correct undistortion of images.
+        private static Metadata AppendMetadataByDeviceMetadata(Metadata metadata, NodeMap nodeMap)
+        {
+            metadata.SetValueByKey(MetadataKeys.BinningHorizontal,
+                (uint) nodeMap.FindNode<IntegerNode>("BinningHorizontal").Value());
+
+            metadata.SetValueByKey(MetadataKeys.BinningVertical,
+                (uint) nodeMap.FindNode<IntegerNode>("BinningVertical").Value());
+
+            var roi = new RectangleU(
+                (uint) nodeMap.FindNode<IntegerNode>("OffsetX").Value(),
+                (uint) nodeMap.FindNode<IntegerNode>("OffsetY").Value(),
+                (uint) nodeMap.FindNode<IntegerNode>("Width").Value(),
+                (uint) nodeMap.FindNode<IntegerNode>("Height").Value());
+
+            metadata.SetValueByKey(MetadataKeys.Roi, roi);
+
+            return metadata;
+        }
+
+        // -------------------------------------------------------------------------------------------------------------
+        // ACQUISITION
+        // -------------------------------------------------------------------------------------------------------------
+
+        private static DataStream DeviceStartAcquisition(Device device, NodeMap nodeMap)
+        {
+            DataStream stream = device.DataStreams()[0].OpenDataStream();
+
+            nodeMap.FindNode<EnumerationNode>("AcquisitionMode").SetCurrentEntry("Continuous");
+
+            var payloadSize = (uint) nodeMap.FindNode<IntegerNode>("PayloadSize").Value();
+
+            for (var i = 0; i < stream.NumBuffersAnnouncedMinRequired(); i++)
+            {
+                stream.QueueBuffer(stream.AllocAndAnnounceBuffer(payloadSize, IntPtr.Zero));
+            }
+
+            nodeMap.FindNode<IntegerNode>("TLParamsLocked").SetValue(1);
+
+            stream.StartAcquisition();
+
+            using CommandNode cmd = nodeMap.FindNode<CommandNode>("AcquisitionStart");
+            cmd.Execute();
+            cmd.WaitUntilDone();
+
+            return stream;
+        }
+
+        private static (BufferPart depth, BufferPart intensity) ExtractBufferParts(Buffer buffer)
+        {
+            BufferPart depth = null;
+            BufferPart intensity = null;
+
+            foreach (BufferPart part in buffer.Parts())
+            {
+                if (part.Type() == BufferPartType.Image3D)
+                {
+                    depth = part;
+                }
+                else if (part.Type() == BufferPartType.Image2D)
+                {
+                    intensity = part;
+                }
+            }
+
+            if (depth == null || intensity == null)
+            {
+                throw new Exception("Missing buffer parts");
+            }
+
+            return (depth, intensity);
+        }
+
+        private static void DeviceStopAcquisition(NodeMap nodeMap, DataStream stream)
+        {
+            using CommandNode cmd = nodeMap.FindNode<CommandNode>("AcquisitionStop");
+            cmd.Execute();
+            cmd.WaitUntilDone();
+
+            stream.StopAcquisition();
+            nodeMap.FindNode<IntegerNode>("TLParamsLocked").SetValue(0);
+
+            stream.Flush(DataStreamFlushMode.DiscardAll);
+
+            foreach (Buffer b in stream.AnnouncedBuffers())
+            {
+                stream.RevokeBuffer(b);
+            }
+        }
+
+        // -------------------------------------------------------------------------------------------------------------
+        // FILE OUTPUT
+        // -------------------------------------------------------------------------------------------------------------
+        private static void WriteDepthMapToFile(Image depthMap, int i)
+        {
+            var writer = new ImageWriter();
+            var path = $"undistorted_depth_map_{i}.tiff";
+            writer.Write(path, depthMap);
+            Console.WriteLine(path);
+        }
+
+        private static void WriteIntensityToFile(Image intensity, int i)
+        {
+            var writer = new ImageWriter();
+            var path = $"undistorted_intensity_image_{i}.png";
+            writer.Write(path, intensity);
+            Console.WriteLine(path);
+        }
+
+        private static void WritePointCloudToFile(PointCloudXYZI pointCloud, int i)
+        {
+            var writer = new PointCloudWriter();
+            var path = $"point_cloud_xyzi_{i}.ply";
+            writer.Write(path, pointCloud);
+            Console.WriteLine(path);
+        }
+    }
+}

--- a/csharp/NionPointCloud/README.md
+++ b/csharp/NionPointCloud/README.md
@@ -1,0 +1,56 @@
+# NionPointCloud Example
+
+Demonstrates how to acquire multipart image data from an **IDS Nion** camera
+and convert it into a metric 3D point cloud with per-point intensity information (XYZI).
+
+This example shows how to open and configure an IDS Nion camera,
+acquire multipart image buffers containing a depth map and an intensity image,
+and process this data into usable 3D information.
+It illustrates how to convert raw depth values into floating-point metric coordinates,
+filter invalid or out-of-range depth measurements,
+and apply factory calibration data to undistort both depth and intensity images.
+
+In addition, the example demonstrates how to generate a point cloud from the processed depth data,
+associate each 3D point with an intensity value,
+and write the resulting depth maps, intensity images, and point cloud data to disk
+for further processing or visualization.
+
+## Requirements
+
+This example requires:
+
+* **C# 8.0 or later**
+* **.NET Framework 4.8** (for classic projects)
+* **.NET 8** (for modern SDK-style projects)
+
+> **Note:** The C# bindings include the necessary runtime DLLs to run
+> the examples. Installing the IDS peak Runtime Setup is still required
+> to provide the drivers and GenTL libraries for device access.
+
+## Build Instructions
+
+The IDS peak SDK uses **native (unmanaged) DLLs**, so you **must specify
+the `Platform` parameter** when building.
+
+### .NET (modern, SDK-style)
+
+```bash
+dotnet build NionPointCloud.csproj
+dotnet run --project NionPointCloud.csproj
+```
+
+> Optional (smaller output):[NionPointCloudFramework.csproj](NionPointCloudFramework.csproj)
+>
+> ```bash
+> dotnet build -r win-x64 NionPointCloud.csproj
+> dotnet run   -r win-x64 --project NionPointCloud.csproj
+> ```
+
+### .NET Framework (classic)
+
+Use Visual Studio **or**:
+
+```bash
+msbuild NionPointCloudFramework.csproj /t:Restore
+msbuild NionPointCloudFramework.csproj /p:Platform=x64
+```

--- a/csharp/PeakExamples.sln
+++ b/csharp/PeakExamples.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36327.8
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -11,6 +11,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unicast", "Unicast\Unicast.csproj", "{2A780A15-C157-6535-4CBB-D6826F3E6687}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipeline", "Pipeline\Pipeline.csproj", "{09A0F5DA-E97D-7E68-E74F-C1E2A374D290}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NionPointCloud", "NionPointCloud\NionPointCloud.csproj", "{43BC90CC-AB89-4E55-9CB9-427897097D5C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemTimestamp", "SystemTimestamp\SystemTimestamp.csproj", "{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}"
 EndProject
@@ -148,6 +150,26 @@ Global
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Release|x64.Build.0 = Release|x64
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Release|x86.ActiveCfg = Release|x86
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Release|x86.Build.0 = Release|x86
+		{43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM32.ActiveCfg = Debug|ARM32
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM32.Build.0 = Debug|ARM32
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM64.ActiveCfg = Debug|ARM64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM64.Build.0 = Debug|ARM64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x64.ActiveCfg = Debug|x64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x64.Build.0 = Debug|x64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x86.ActiveCfg = Debug|x86
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x86.Build.0 = Debug|x86
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM32.ActiveCfg = Release|ARM32
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM32.Build.0 = Release|ARM32
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM64.ActiveCfg = Release|ARM64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM64.Build.0 = Release|ARM64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x64.ActiveCfg = Release|x64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x64.Build.0 = Release|x64
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x86.ActiveCfg = Release|x86
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/PeakExamplesFramework.sln
+++ b/csharp/PeakExamplesFramework.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnicastFramework", "Unicast
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineFramework", "Pipeline\PipelineFramework.csproj", "{F9BD9A7E-C674-4FCB-94F0-569287EBC7D1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NionPointCloudFramework", "NionPointCloud\NionPointCloudFramework.csproj", "{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemTimestampFramework", "SystemTimestamp\SystemTimestampFramework.csproj", "{DC212522-F187-497E-98EC-D009013EA4B3}"
 EndProject
 Global
@@ -70,6 +72,14 @@ Global
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Release|x64.Build.0 = Release|x64
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Release|x86.ActiveCfg = Release|x86
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Release|x86.Build.0 = Release|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x64.ActiveCfg = Debug|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x64.Build.0 = Debug|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x86.ActiveCfg = Debug|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x86.Build.0 = Debug|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x64.ActiveCfg = Release|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x64.Build.0 = Release|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x86.ActiveCfg = Release|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/PeakExamplesFrameworkWindows.sln
+++ b/csharp/PeakExamplesFrameworkWindows.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36327.8
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleLiveWindowsFormsFramework", "SimpleLiveWindowsForms\SimpleLiveWindowsFormsFramework.csproj", "{ABBCE9C6-C990-4D03-9312-D503FFE852DB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineFramework", "Pipeline\PipelineFramework.csproj", "{F9BD9A7E-C674-4FCB-94F0-569287EBC7D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NionPointCloudFramework", "NionPointCloud\NionPointCloudFramework.csproj", "{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemTimestampFramework", "SystemTimestamp\SystemTimestampFramework.csproj", "{DC212522-F187-497E-98EC-D009013EA4B3}"
 EndProject
@@ -72,6 +74,14 @@ Global
 		{ABBCE9C6-C990-4D03-9312-D503FFE852DB}.Release|x64.Build.0 = Release|x64
 		{ABBCE9C6-C990-4D03-9312-D503FFE852DB}.Release|x86.ActiveCfg = Release|x86
 		{ABBCE9C6-C990-4D03-9312-D503FFE852DB}.Release|x86.Build.0 = Release|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x64.ActiveCfg = Debug|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x64.Build.0 = Debug|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x86.ActiveCfg = Debug|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Debug|x86.Build.0 = Debug|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x64.ActiveCfg = Release|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x64.Build.0 = Release|x64
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x86.ActiveCfg = Release|x86
+		{D50C5F0E-D0AE-4CEB-B1FE-95A155E30473}.Release|x86.Build.0 = Release|x86
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Debug|x64.ActiveCfg = Debug|x64
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Debug|x64.Build.0 = Debug|x64
 		{DC212522-F187-497E-98EC-D009013EA4B3}.Debug|x86.ActiveCfg = Debug|x86

--- a/csharp/PeakExamplesWindows.sln
+++ b/csharp/PeakExamplesWindows.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipeline", "Pipeline\Pipeli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleLiveWindowsForms", "SimpleLiveWindowsForms\SimpleLiveWindowsForms.csproj", "{200BE118-D69B-E652-2B8E-8AE392D7F318}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NionPointCloud", "NionPointCloud\NionPointCloud.csproj", "{43BC90CC-AB89-4E55-9CB9-427897097D5C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemTimestamp", "SystemTimestamp\SystemTimestamp.csproj", "{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}"
 EndProject
 Global
@@ -150,6 +152,26 @@ Global
 		{200BE118-D69B-E652-2B8E-8AE392D7F318}.Release|x64.Build.0 = Release|Any CPU
 		{200BE118-D69B-E652-2B8E-8AE392D7F318}.Release|x86.ActiveCfg = Release|Any CPU
 		{200BE118-D69B-E652-2B8E-8AE392D7F318}.Release|x86.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM32.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM32.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|ARM64.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x64.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x86.ActiveCfg = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Debug|x86.Build.0 = Debug|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM32.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM32.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM64.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|ARM64.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x64.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x64.Build.0 = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x86.ActiveCfg = Release|Any CPU
+        {43BC90CC-AB89-4E55-9CB9-427897097D5C}.Release|x86.Build.0 = Release|Any CPU
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63CD24AC-7ADA-5FC8-B07C-D7AE5A9DEE41}.Debug|ARM32.ActiveCfg = Debug|ARM32

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -78,6 +78,7 @@ dotnet add package IDSImaging.Peak.<PackageName>
 ## Included Examples
 
 - [Firmware Update](FirmwareUpdate) Shows how to programatically update the firmware of a device.
+- [Nion Point Cloud](NionPointCloud) Command-line example demonstrating Nion Point Cloud acquisition.
 - [OpenCamera](OpenCamera) Command-line example demonstrating device enumeration and access.
 - [Reconnect](Reconnect) Command-line example demonstrating robust device reconnect handling.
 - [SimpleLiveWindowsForms](SimpleLiveWindowsForms) Windows Forms application demonstrating a basic


### PR DESCRIPTION
Add .NET example that shows how to open and configure an IDS Nion camera,
acquire multipart image buffers containing a depth map and an intensity image,
and process this data into usable 3D information.