### PR TITLE
fix: Prevent premature disposal of DeviceManager singleton

### DIFF
--- a/csharp/NionPointCloud/Program.cs
+++ b/csharp/NionPointCloud/Program.cs
@@ -237,7 +237,7 @@ namespace IDSImaging.Peak.Examples.NionPointCloud
 
         private static Device OpenFirstConnectedDevice()
         {
-            using var deviceManager = DeviceManager.Instance();
+            var deviceManager = DeviceManager.Instance();
             deviceManager.Update();
 
             foreach (DeviceDescriptor deviceDescriptor in deviceManager.Devices())


### PR DESCRIPTION
Avoid querying the DeviceManager singleton with `using var`, which can cause it to be disposed prematurely by the garbage collector and lead to exceptions.

See: https://de.ids-imaging.com/manuals/ids-peak/ids-peak-api-documentation/2.21/en/csharp_dotnet.html#csharpUsage